### PR TITLE
New state machines for Orient and Navigate

### DIFF
--- a/mbzirc_c2_auto/bin/arm_kalman_move.py
+++ b/mbzirc_c2_auto/bin/arm_kalman_move.py
@@ -11,102 +11,103 @@ import scipy.linalg as linalg
 
 class arm_kalman:
 
-  def __init__(self):
-    self.est_pose = rospy.Publisher("/move_arm/valve_pos_kf",Twist, queue_size=1)
-    self.input_pose = rospy.Subscriber("/move_arm/valve_pos",Twist,self.gen_kf_position,queue_size=1)
-    self.kf_init = rospy.Subscriber("/move_arm/kf_init",kf_msg,self.init_KF,queue_size=1)
+    def __init__(self):
+        self.est_pose = rospy.Publisher("/move_arm/valve_pos_kf",Twist, queue_size=1)
+        self.input_pose = rospy.Subscriber("/move_arm/valve_pos",Twist,self.gen_kf_position,queue_size=1)
+        self.kf_init = rospy.Subscriber("/move_arm/kf_init",kf_msg,self.init_KF,queue_size=1)
 
-    zeroPos = np.array([0.0 , 0.0])
-    initCv = 0.01 * np.eye(2)
+        zeroPos = np.array([0.0 , 0.0])
+        initCv = 0.01 * np.eye(2)
 
-    self.mx_kmGkm = zeroPos
-    self.Sx_kmGkm = np.eye(2)
-    self.Sw_km = initCv
-    self.Sv_k = initCv
-    self.u = np.array([0.0 , 0.0])
+        self.mx_kmGkm = zeroPos
+        self.Sx_kmGkm = np.eye(2)
+        self.Sw_km = initCv
+        self.Sv_k = initCv
+        self.u = np.array([0.0 , 0.0])
 
-    self.ready_to_init = True
-
-
-  def gen_kf_position(self,data):
-    '''Callback to generate a new filtered position
-    '''
-    rospy.loginfo("Computing the RBE for valve move.")
-    I = np.eye(2)
-
-    # Obtain the current measured valve position
-    zk = np.array([data.linear.y , data.linear.z])
+        self.ready_to_init = True
 
 
-    # Prediction Step
-    mx_kGkm = self.mx_kmGkm + self.u
-    Sx_kGkm = self.Sx_kmGkm + self.Sw_km
+    def gen_kf_position(self,data):
+        '''Callback to generate a new filtered position
+        '''
+        rospy.loginfo("Computing the RBE for valve move.")
+        I = np.eye(2)
 
-    # Correction Step
-    K_den = Sx_kGkm + self.Sv_k
-    Kk = linalg.solve(K_den.T , Sx_kGkm.T)
-    Kk = Kk.T
-    mx_kGk = mx_kGkm + (Kk.dot(zk - mx_kGkm))
-    tmp = (I - Kk)
-    Sx_kGk = tmp.dot(Sx_kGkm)
-
-    rospy.logdebug("u       = %6.3f | %6.3f", self.u[0], self.u[1])
-    rospy.logdebug("z_k     = %6.3f | %6.3f", zk[0], zk[1])
-    rospy.logdebug("mx_kmkm = %6.3f | %6.3f", self.mx_kmGkm[0], self.mx_kmGkm[1])
-    rospy.logdebug("Sx_kmkm = %6.3f | %6.3f", self.Sx_kmGkm[0,0], self.Sx_kmGkm[1,1])
-    rospy.logdebug("mx_kkm  = %6.3f | %6.3f", mx_kGkm[0], mx_kGkm[1])
-    rospy.logdebug("Sx_kkm  = %6.3f | %6.3f", Sx_kGkm[0,0], Sx_kGkm[1,1])
-    rospy.logdebug("K       = %6.3f | %6.3f", Kk[0,0], Kk[1,1])
-    rospy.logdebug("mx_kk   = %6.3f | %6.3f", mx_kGk[0], mx_kGk[1])
-    rospy.logdebug("Sx_kk   = %6.3f | %6.3f", Sx_kGk[0,0], Sx_kGk[1,1])
-
-    curr_pose = data
-    rospy.loginfo("Original (x,y,z) pose:      (%6.4f, %6.4f, %6.4f)",
-                  curr_pose.linear.x,
-                  curr_pose.linear.y,
-                  curr_pose.linear.z)
-
-    # Publish estimated valve position
-    est_valve_pose = data
-    est_valve_pose.linear.y = mx_kGk[0]
-    est_valve_pose.linear.z = mx_kGk[1]
-
-    rospy.loginfo("New estimated (x,y,z) pose: (%6.4f, %6.4f, %6.4f)",
-                  est_valve_pose.linear.x,
-                  est_valve_pose.linear.y,
-                  est_valve_pose.linear.z)
-
-    self.est_pose.publish(est_valve_pose)
-    rospy.sleep(0.1)
-
-    # Populate values for the next step
-    self.u = - mx_kGk
-    self.mx_kmGkm = mx_kGk
-    self.Sx_kmGkm = Sx_kGk
+        # Obtain the current measured valve position
+        zk = np.array([data.linear.y , data.linear.z])
 
 
+        # Prediction Step
+        mx_kGkm = self.mx_kmGkm + self.u
+        Sx_kGkm = self.Sx_kmGkm + self.Sw_km
+
+        # Correction Step
+        K_den = Sx_kGkm + self.Sv_k
+        Kk = linalg.solve(K_den.T , Sx_kGkm.T)
+        Kk = Kk.T
+        mx_kGk = mx_kGkm + (Kk.dot(zk - mx_kGkm))
+        tmp = (I - Kk)
+        Sx_kGk = tmp.dot(Sx_kGkm)
+
+        rospy.logdebug("u       = %6.3f | %6.3f", self.u[0], self.u[1])
+        rospy.logdebug("z_k     = %6.3f | %6.3f", zk[0], zk[1])
+        rospy.logdebug("mx_kmkm = %6.3f | %6.3f", self.mx_kmGkm[0], self.mx_kmGkm[1])
+        rospy.logdebug("Sx_kmkm = %6.3f | %6.3f", self.Sx_kmGkm[0,0], self.Sx_kmGkm[1,1])
+        rospy.logdebug("mx_kkm  = %6.3f | %6.3f", mx_kGkm[0], mx_kGkm[1])
+        rospy.logdebug("Sx_kkm  = %6.3f | %6.3f", Sx_kGkm[0,0], Sx_kGkm[1,1])
+        rospy.logdebug("K       = %6.3f | %6.3f", Kk[0,0], Kk[1,1])
+        rospy.logdebug("mx_kk   = %6.3f | %6.3f", mx_kGk[0], mx_kGk[1])
+        rospy.logdebug("Sx_kk   = %6.3f | %6.3f", Sx_kGk[0,0], Sx_kGk[1,1])
+
+        curr_pose = data
+        rospy.loginfo("Original (x,y,z) pose:      (%6.4f, %6.4f, %6.4f)",
+                      curr_pose.linear.x,
+                      curr_pose.linear.y,
+                      curr_pose.linear.z)
+
+        # Publish estimated valve position
+        est_valve_pose = data
+        est_valve_pose.linear.y = mx_kGk[0]
+        est_valve_pose.linear.z = mx_kGk[1]
+
+        rospy.loginfo("New estimated (x,y,z) pose: (%6.4f, %6.4f, %6.4f)",
+                      est_valve_pose.linear.x,
+                      est_valve_pose.linear.y,
+                      est_valve_pose.linear.z)
+
+        self.est_pose.publish(est_valve_pose)
+        rospy.sleep(0.1)
+
+        # Populate values for the next step
+        self.u = - mx_kGk
+        self.mx_kmGkm = mx_kGk
+        self.Sx_kmGkm = Sx_kGk
 
 
-  def init_KF(self,init_data):
-    '''Callback to initialize the Kalman filter
-    '''
-    rospy.loginfo("Initializing the Kalman filter")
-    self.mx_kmGkm = np.array([init_data.initial_pos[1],init_data.initial_pos[2]])
-    self.Sx_kmGkm = np.diag(init_data.initial_covar)
-    self.Sw_km = np.diag(init_data.covar_motion)
-    self.Sv_k = np.diag(init_data.covar_observer)
-    self.u = np.array([0.0 , 0.0])
-    rospy.logdebug(init_data)
+
+
+    def init_KF(self,init_data):
+        '''Callback to initialize the Kalman filter
+        '''
+        rospy.loginfo("Initializing the Kalman filter")
+        self.mx_kmGkm = np.array([init_data.initial_pos[1],init_data.initial_pos[2]])
+        self.Sx_kmGkm = np.diag(init_data.initial_covar)
+        self.Sw_km = np.diag(init_data.covar_motion)
+        self.Sv_k = np.diag(init_data.covar_observer)
+        self.u = np.array([0.0 , 0.0])
+        rospy.logdebug(init_data)
 
 
 def main(args):
-  rospy.init_node('arm_kalman', anonymous=True, log_level=rospy.DEBUG)
-  # rospy.init_node('arm_kalman', anonymous=True, log_level=rospy.INFO)
-  kf = arm_kalman()
-  try:
-    rospy.spin()
-  except KeyboardInterrupt:
-    print("Shutting down")
+
+    rospy.init_node('arm_kalman', anonymous=True, log_level=rospy.DEBUG)
+    # rospy.init_node('arm_kalman', anonymous=True, log_level=rospy.INFO)
+    arm_kalman()
+    try:
+        rospy.spin()
+    except KeyboardInterrupt:
+        print("Shutting down")
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/mbzirc_c2_auto/bin/grasp.py
+++ b/mbzirc_c2_auto/bin/grasp.py
@@ -21,18 +21,7 @@
 """
 
 import rospy
-import rospkg
-import actionlib
-from actionlib_msgs.msg import *
-from geometry_msgs.msg import Pose, PoseWithCovarianceStamped, Point, Quaternion, Twist
-from move_base_msgs.msg import MoveBaseAction, MoveBaseGoal, MoveBaseFeedback
-from rospy.numpy_msg import numpy_msg
-from rospy_tutorials.msg import Floats
-import numpy as np
-from decimal import *
-import tf
-import math
-import random
+from geometry_msgs.msg import Twist
 
 if __name__ == '__main__':
     rospy.init_node('grasp')
@@ -51,7 +40,7 @@ if __name__ == '__main__':
     ct = 0
     rest_time = 0.1
     tot_time = 1
-    
+
     while ct*rest_time < tot_time:
         pub.publish(twist)
         rospy.sleep(0.1)
@@ -67,9 +56,6 @@ if __name__ == '__main__':
         rospy.sleep(0.1)
         ct = ct+1
 
-    #if random.random() < 0.1:
-    #    rospy.set_param('smach_state','gripFailure')
-    #else:
     rospy.set_param('smach_state','wrenchGrasped')
     rospy.signal_shutdown('Ending node.')
 

--- a/mbzirc_c2_auto/bin/key_publisher.py
+++ b/mbzirc_c2_auto/bin/key_publisher.py
@@ -34,14 +34,14 @@ from std_msgs.msg import String
 
 if __name__ == '__main__':
     key_pub = rospy.Publisher('keys',String,queue_size=1)
-    rospy.init_node("keyboard_driver")
+    rospy.init_node("key_publisher")
     rate = rospy.Rate(100)
     old_attr = termios.tcgetattr(sys.stdin)
     tty.setcbreak(sys.stdin.fileno())
-    rospy.loginfo("Publishing keystrokes to 'keys' topic. Press 'Q' to quit...")
+    rospy.loginfo("Publishing keystrokes to 'keys' topic.")
     while not rospy.is_shutdown():
         if select.select([sys.stdin], [], [], 0)[0] == [sys.stdin]:
             key_pub.publish(sys.stdin.read(1))
         rate.sleep()
-    rospy.loginfo('Ending key publisher')
+    rospy.loginfo('Ending key_publisher')
     termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_attr)

--- a/mbzirc_c2_auto/bin/key_publisher.py
+++ b/mbzirc_c2_auto/bin/key_publisher.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+"""key_pulisher.py - Version 1.0 2016-12-27
+Author: Alan Lattimer
+
+This reads keystrokes from the stdin stream and publishes them to a topic for
+use in moving the robot
+
+Publishers:
+    /keys : keystrokes from stdin stream
+
+Acknowledgments:
+    This code was based on Example 8.1 of 'Programming Robots with ROS', M. Quigley,
+    B. Gerkey, and W. D. Smart, 2015
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details at:
+http://www.gnu.org/licenses/gpl.html
+
+"""
+
+import sys
+import select
+import tty
+import termios
+import rospy
+from std_msgs.msg import String
+
+if __name__ == '__main__':
+    key_pub = rospy.Publisher('keys',String,queue_size=1)
+    rospy.init_node("keyboard_driver")
+    rate = rospy.Rate(100)
+    old_attr = termios.tcgetattr(sys.stdin)
+    tty.setcbreak(sys.stdin.fileno())
+    rospy.loginfo("Publishing keystrokes to 'keys' topic. Press 'Q' to quit...")
+    while not rospy.is_shutdown():
+        if select.select([sys.stdin], [], [], 0)[0] == [sys.stdin]:
+            key_pub.publish(sys.stdin.read(1))
+        rate.sleep()
+    rospy.loginfo('Ending key publisher')
+    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_attr)

--- a/mbzirc_c2_auto/bin/manual_arm_move.py
+++ b/mbzirc_c2_auto/bin/manual_arm_move.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+"""manual_arm_move.py - Version 1.0 2016-12-27
+Author: Alan Lattimer
+
+Reads in the keys topic an moves the end effector of the arm based on the
+keys entered.
+
+Subscribers:
+    /keys : keystrokes from stdin stream
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details at:
+http://www.gnu.org/licenses/gpl.html
+
+"""
+
+import rospy
+import rosnode
+import subprocess
+from std_msgs.msg import String
+
+
+class manual_arm_move():
+    def __init__(self):
+        # Name the node
+        rospy.init_node('manual_arm_move', anonymous=True)
+
+        rospy.loginfo('Beginning manual operation of the arm.')
+        rospy.loginfo('  Operate the arm by pressing the following keys:')
+        rospy.loginfo('    k - move up')
+        rospy.loginfo('    j - move down')
+        rospy.loginfo('    h - move left')
+        rospy.loginfo('    l - move right')
+        rospy.loginfo('    u - move forward')
+        rospy.loginfo('    m - move backward')
+        rospy.loginfo('    a - rotate gripper counter-clockwise')
+        rospy.loginfo('    d - rotate gripper clockwise')
+        rospy.loginfo('    s - stop')
+        rospy.loginfo('    q - quit')
+        rospy.loginfo('    z - return to autonomous operation')
+
+        # Set rospy to execute a shutdown function when exiting
+        rospy.on_shutdown(self.shutdown_manops)
+
+        self.get_keys = subprocess.Popen("rosrun mbzirc_c2_auto key_publisher.py", shell=True)
+
+        self.key_sub = rospy.Subscriber('keys',String,self.key_cb)
+
+    def shutdown_manops(exit_str):
+        """Kill the key_publisher node
+        """
+        rospy.logdebug('Attempting to kill keyboard_driver')
+        rosnode.kill_nodes(['key_publisher'])
+
+    def key_cb(self, data):
+        """Callback used when a key is pressed and published
+        """
+        self.curr_key = data.data.lower()
+
+        if self.curr_key == 'q':
+            rospy.set_param('smach_state','endArmMove')
+            rospy.sleep(1)
+            rospy.signal_shutdown('Ending node. Stopping arm moves.')
+        elif self.curr_key == 'z':
+            rospy.set_param('smach_state','backToAuto')
+            rospy.sleep(1)
+            rospy.signal_shutdown('Ending node. Returning to autonomous mode.')
+        elif self.curr_key == 'k':
+            rospy.loginfo('Arm moving up.')
+        elif self.curr_key == 'j':
+            rospy.loginfo('Arm moving down.')
+        elif self.curr_key == 'h':
+            rospy.loginfo('Arm moving left.')
+        elif self.curr_key == 'l':
+            rospy.loginfo('Arm moving right.')
+        elif self.curr_key == 'u':
+            rospy.loginfo('Arm moving forward.')
+        elif self.curr_key == 'm':
+            rospy.loginfo('Arm moving backward.')
+        elif self.curr_key == 'a':
+            rospy.loginfo('Gripper turning counter-clockwise')
+        elif self.curr_key == 'd':
+            rospy.loginfo('Gripper turning clockwise')
+        elif self.curr_key == 's':
+            rospy.loginfo('Arm stopping.')
+
+if __name__ == '__main__':
+    try:
+        manual_arm_move()
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        rospy.loginfo("Manual Arm operation finished.")

--- a/mbzirc_c2_auto/bin/manual_orient.py
+++ b/mbzirc_c2_auto/bin/manual_orient.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+"""key_pulisher.py - Version 1.0 2016-12-27
+Author: Alan Lattimer
+
+This reads keystrokes from the stdin stream and publishes them to a topic for
+use in moving the robot
+
+Publishers:
+    /keys : keystrokes from stdin stream
+
+Acknowledgments:
+    This code was based on Example 8.1 of 'Programming Robots with ROS', M. Quigley,
+    B. Gerkey, and W. D. Smart, 2015
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details at:
+http://www.gnu.org/licenses/gpl.html
+
+"""
+
+import rospy
+import rosnode
+import subprocess
+from std_msgs.msg import String
+
+
+class manual_orient():
+    def __init__(self):
+        # Name this node, it must be unique
+        rospy.init_node('manual_orient', anonymous=True)
+
+        rospy.loginfo('Beginning manual operation of the UGV.')
+        rospy.loginfo('  Operate the UGV by pressing the following keys:')
+        rospy.loginfo('    w - move forward')
+        rospy.loginfo('    x - move backward')
+        rospy.loginfo('    a - turn left')
+        rospy.loginfo('    d - turn right')
+        rospy.loginfo('    s - stop')
+        rospy.loginfo('    q - quit')
+        rospy.loginfo('    z - return to autonomous operation')
+
+        # Enable shutdown in rospy
+        rospy.on_shutdown(self.shutdown_manops) # Set rospy to execute a shutdown function when exiting
+
+        self.get_keys = subprocess.Popen("rosrun mbzirc_c2_auto key_publisher.py", shell=True)
+
+        self.key_sub = rospy.Subscriber('keys',String,self.callback)
+
+    def shutdown_manops(exit_str):
+        print exit_str
+        rospy.loginfo('Attempting to kill keyboard_driver')
+        rosnode.kill_nodes(['keyboard_driver'])
+
+    # callback_wrench is used to store the wrench topic into the class to be
+    # referenced by the other callback routines.
+    def callback(self, data):
+        self.curr_key = data.data.lower()
+
+        if self.curr_key == 'q':
+            rospy.set_param('smach_state','noWrenches')
+            rospy.sleep(1)
+            rospy.signal_shutdown('Ending node. Unable to find wrenches.')
+        elif self.curr_key == 'z':
+            rospy.set_param('smach_state','backToAuto')
+            rospy.sleep(1)
+            rospy.signal_shutdown('Ending node. Returning to autonomous mode.')
+        elif self.curr_key == 'w':
+            rospy.loginfo('UGV moving forward.')
+        elif self.curr_key == 'x':
+            rospy.loginfo('UGV moving backward.')
+        elif self.curr_key == 'a':
+            rospy.loginfo('UGV turning left.')
+        elif self.curr_key == 'd':
+            rospy.loginfo('UGV turning right.')
+        elif self.curr_key == 's':
+            rospy.loginfo('UGV stopping.')
+
+if __name__ == '__main__':
+    try:
+        manual_orient()
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        rospy.loginfo("Manual UGV operation finished.")

--- a/mbzirc_c2_auto/bin/move2grasp.py
+++ b/mbzirc_c2_auto/bin/move2grasp.py
@@ -40,8 +40,8 @@ import math
 class move2grasp():
     def __init__(self):
         # Name this node, it must be unique
-	rospy.init_node('move2grasp', anonymous=True)
-        
+        rospy.init_node('move2grasp', anonymous=True)
+
         # Enable shutdown in rospy (This is important so we cancel any move_base goals
         # when the node is killed)
         rospy.on_shutdown(self.shutdown) # Set rospy to execute a shutdown function when exiting

--- a/mbzirc_c2_auto/launch/ch2-armtest.launch
+++ b/mbzirc_c2_auto/launch/ch2-armtest.launch
@@ -1,9 +1,8 @@
 <?xml version="1.0"?>
 <launch>
-<!--   <env name="ROSCONSOLE_CONFIG_FILE"
-       value="$(find mbzirc_c2_auto)/params/debugconsole.config"/>
+  <param name="node_logging" value="DEBUG"/>
 
- -->  <include file="$(find mbzirc_c2_auto)/launch/h-arena2-wrench.launch">
+  <include file="$(find mbzirc_c2_auto)/launch/h-arena2-wrench.launch">
     <arg name="paused" value="true" />
     <arg name="ur5_camera_enabled" value="false"/>
     <arg name="kinectv2_enabled" value="true"/>

--- a/mbzirc_c2_auto/launch/ch2-nosmach.launch
+++ b/mbzirc_c2_auto/launch/ch2-nosmach.launch
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
+  <param name="node_logging" value="INFO"/>
+
   <include file="$(find mbzirc_c2_auto)/launch/h-arena2-wrench.launch">
     <arg name="paused" value="true" />
     <arg name="ur5_camera_enabled" value="false"/>

--- a/mbzirc_c2_auto/launch/ch2-playpen.launch
+++ b/mbzirc_c2_auto/launch/ch2-playpen.launch
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
+  <param name="node_logging" value="INFO"/>
+
   <include file="$(find mbzirc_c2_auto)/launch/h-playpen.launch">
     <arg name="paused" value="true" />
     <arg name="ur5_camera_enabled" value="false"/>

--- a/mbzirc_c2_auto/launch/ch2-smach.launch
+++ b/mbzirc_c2_auto/launch/ch2-smach.launch
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
+  <param name="node_logging" value="INFO"/>
+
   <include file="$(find mbzirc_c2_auto)/launch/h-arena2.launch">
     <arg name="paused" value="true" />
     <arg name="ur5_camera_enabled" value="false"/>

--- a/mbzirc_c2_auto/launch/ch2-wrenchtest.launch
+++ b/mbzirc_c2_auto/launch/ch2-wrenchtest.launch
@@ -1,9 +1,8 @@
 <?xml version="1.0"?>
 <launch>
-<!--   <env name="ROSCONSOLE_CONFIG_FILE"
-   value="$(find mbzirc_c2_auto)/params/debugconsole.config"/>
- -->
-   <include file="$(find mbzirc_c2_auto)/launch/h-arena2-wrench.launch">
+  <param name="node_logging" value="DEBUG"/>
+
+  <include file="$(find mbzirc_c2_auto)/launch/h-arena2-wrench.launch">
     <arg name="paused" value="true" />
     <arg name="ur5_camera_enabled" value="false"/>
     <arg name="kinectv2_enabled" value="true"/>

--- a/mbzirc_c2_state/bin/grasp_wrench_states.py
+++ b/mbzirc_c2_state/bin/grasp_wrench_states.py
@@ -109,11 +109,6 @@ class MoveToWrenchReady(smach.State):
 
         move_state = moveArmTwist(wrench_ready_pos[0], wrench_ready_pos[1], wrench_ready_pos[2])
 
-        #prc = subprocess.Popen("rosrun mbzirc_grasping move_arm_param.py", shell=True)
-        #prc.wait()
-
-        #move_state = rospy.get_param('move_arm_status')
-
         # Preset the out move counter to 0, override if necessary
         userdata.move_counter_out = 0
 
@@ -122,23 +117,6 @@ class MoveToWrenchReady(smach.State):
             if userdata.got_wrench is True:
                 return 'moveToOperate'
             else:
-                ve = 0.1
-                dist_to_move = 0.0
-                sleep_time = 0.1
-                time_to_move = abs(dist_to_move/ve)
-                twist = Twist()
-                twist.linear.x = ve
-                twist.linear.y = 0
-                twist.linear.z = 0
-                twist.angular.x = 0
-                twist.angular.y = 0
-                twist.angular.z = 0
-                twi_pub = rospy.Publisher("/joy_teleop/cmd_vel", Twist, queue_size=10)
-                ct_move = 0
-                while ct_move*sleep_time < time_to_move:
-                    twi_pub.publish(twist)
-                    ct_move = ct_move+1
-                    rospy.sleep(sleep_time)
                 return 'atWrenchReady'
 
 
@@ -207,8 +185,11 @@ class MoveToWrench(smach.State):
         wrench_id = rospy.get_param('wrench_ID_m')
         rospy.sleep(0.1)
         ee_position = rospy.get_param('ee_position')
-        print "wrench_id", wrench_id
-        print "ee_position", ee_position
+        rospy.logdebug("wrench_id: [%f, %f, %f]", wrench_id[0], wrench_id[1], wrench_id[2])
+        rospy.logdebug("ee_position: [%f, %f, %f]",
+                       ee_position[0],
+                       ee_position[1],
+                       ee_position[2])
         # Set the ready position 40 cm away from the wrenches
         wrench_id[0] = ee_position[0]+wrench_id[0]-0.6
         wrench_id[1] = ee_position[1]+wrench_id[1]
@@ -220,25 +201,24 @@ class MoveToWrench(smach.State):
 
         move_state = moveArmTwist(wrench_id[0], wrench_id[1], wrench_id[2])
 
-        #prc = subprocess.Popen("rosrun mbzirc_grasping move_arm_param.py", shell=True)
-        #prc.wait()
-        ve = 0.1
-        dist_to_move = 0.2
-        sleep_time = 0.1
-        time_to_move = abs(dist_to_move/ve)
-        twist = Twist()
-        twist.linear.x = ve
-        twist.linear.y = 0
-        twist.linear.z = 0
-        twist.angular.x = 0
-        twist.angular.y = 0
-        twist.angular.z = 0
-        twi_pub = rospy.Publisher("/joy_teleop/cmd_vel", Twist, queue_size=10)
-        ct_move = 0
-        while ct_move*sleep_time < time_to_move:
-            twi_pub.publish(twist)
-            ct_move = ct_move+1
-            rospy.sleep(sleep_time)
+        moveUGVvel(0.1,0.2,'linear')
+        # ve = 0.1
+        # dist_to_move = 0.2
+        # sleep_time = 0.1
+        # time_to_move = abs(dist_to_move/ve)
+        # twist = Twist()
+        # twist.linear.x = ve
+        # twist.linear.y = 0
+        # twist.linear.z = 0
+        # twist.angular.x = 0
+        # twist.angular.y = 0
+        # twist.angular.z = 0
+        # twi_pub = rospy.Publisher("/joy_teleop/cmd_vel", Twist, queue_size=10)
+        # ct_move = 0
+        # while ct_move*sleep_time < time_to_move:
+        #     twi_pub.publish(twist)
+        #     ct_move = ct_move+1
+        #     rospy.sleep(sleep_time)
         move_state = rospy.get_param('move_arm_status')
         wrench_id[0] = wrench_id[0]-dist_to_move
         rospy.set_param('wrench_ID_m',wrench_id)
@@ -269,7 +249,7 @@ class MoveToWrench(smach.State):
             rospy.sleep(0.1)
             wrench_id = rospy.get_param('wrench_ID_m')
             wrench_id[0]
-            print "Wrench ID: ", wrench_id
+            rospy.logdebug("Wrench ID: [%f, %f, %f]", wrench_id[0], wrench_id[1], wrench_id[2])
             thresh = 10
             xA = 20
             ee_position = rospy.get_param('ee_position')
@@ -303,21 +283,30 @@ class MoveToWrench(smach.State):
                 rospy.sleep(0.1)
                 wrench_id_px = rospy.get_param('wrench_ID')
                 rospy.sleep(0.1)
-                print "wrench_id", wrench_id
-                print "Wrench_id_px: ", wrench_id_px
+                rospy.logdebug("wrench_id: [%f, %f, %f]", wrench_id[0], wrench_id[1], wrench_id[2])
+                rospy.logdebug("Wrench_id_px: [%f, %f, %f]",
+                               wrench_id_px[0],
+                               wrench_id_px[1],
+                               wrench_id_px[2])
                 dx = wrench_id[0]*0.05
                 xA = rospy.get_param('xA')
                 # Set the ready position 40 cm away from the wrenches
                 ee_position[0] = (xA + 0.461-0.17)+0.005*ct3 # 0.134 distance from camera to left_tip
-                print "ee_position before Kalman filter", ee_position
-                print "************************************************"
+                rospy.logdebug("ee_position before Kalman filter: [%f, %f, %f]",
+                               ee_position[0],
+                               ee_position[1],
+                               ee_position[2])
+                rospy.logdebug("************************************************")
                 ee_twist.linear.x = ee_position[0]
                 ee_twist.linear.y = wrench_id[1]
                 ee_twist.linear.z = wrench_id[2]
                 ee_pub.publish(ee_twist)
                 rospy.sleep(0.1)
                 tw = self.valve_pos_kf
-                print "Estimated pose from Kalman filter: ", tw
+                rospy.logdebug("Estimated pose from Kalman filter:")
+                rospy.logdebug("x = %f", tw.linear.x)
+                rospy.logdebug("y = %f", tw.linear.x)
+                rospy.logdebug("z = %f", tw.linear.x)
 
                 #ee_position[0] = ee_position[0]+0.005 #
                 ee_position[1] = ee_position[1]+tw.linear.y
@@ -326,10 +315,13 @@ class MoveToWrench(smach.State):
                                                 float(ee_position[1]),
                                                 float(ee_position[2])])
                 rospy.sleep(0.1)
-                rospy.set_param('wrench_ID_m',[wrench_id[0]-dx,wrench_id[1],wrench_id[2]])
+                rospy.set_param('wrench_ID_m',[wrench_id[0]-dx, wrench_id[1], wrench_id[2]])
                 rospy.sleep(0.1)
-                print "***********************************************"
-                print "ee_position after Kalman filter", ee_position
+                rospy.logdebug("***********************************************")
+                rospy.logdebug("ee_position after Kalman filter: [%f, %f, %f]",
+                               ee_position[0],
+                               ee_position[1],
+                               ee_position[2])
                 ee_twist.linear.y = ee_position[1]
                 ee_twist.linear.z = ee_position[2]
 
@@ -338,7 +330,7 @@ class MoveToWrench(smach.State):
                 #prc = subprocess.Popen("rosrun mbzirc_grasping move_arm_param.py", shell=True)
                 #prc.wait()
                 ct3 = ct3+1
-            print "We are close enough! Distance = ", dist
+            rospy.logdebug("We are close enough! Distance = %f", dist)
             return 'atWrench'
 
         else:
@@ -389,39 +381,18 @@ class GraspWrench(smach.State):
 
     def execute(self, userdata):
         prc = subprocess.Popen("rosrun mbzirc_c2_auto grasp.py", shell=True)
-        rospy.sleep(2)
-        #prc.wait()
+        # rospy.sleep(2)
+        prc.wait()
         ee_position = rospy.get_param('ee_position')
         ee_position[0] = ee_position[0]-0.1
         rospy.set_param('ee_position', [float(ee_position[0]),
                                         float(ee_position[1]),
                                         float(ee_position[2])])
-        rospy.sleep(0.1)
+        # rospy.sleep(0.1)
 
         move_state = moveArmTwist(ee_position[0], ee_position[1], ee_position[2])
 
-        #prc = subprocess.Popen("rosrun mbzirc_grasping move_arm_param.py", shell=True)
-        #prc.wait()
-
-        #ve = -0.1
-        #dist_to_move = 0.2
-        #sleep_time = 0.1
-        #time_to_move = abs(dist_to_move/ve)
-        #twist = Twist()
-        #twist.linear.x = ve
-        #twist.linear.y = 0
-        #twist.linear.z = 0
-        #twist.angular.x = 0
-        #twist.angular.y = 0
-        #twist.angular.z = 0
-        #twi_pub = rospy.Publisher("/joy_teleop/cmd_vel", Twist, queue_size=10)
-        #ct_move = 0
-        #while ct_move*sleep_time < time_to_move:
-        #    twi_pub.publish(twist)
-        #    ct_move = ct_move+1
-        #    rospy.sleep(sleep_time)
-        #prc.wait()
-        rospy.sleep(0.1)
+        # rospy.sleep(0.1)
         rospy.set_param('smach_state','wrenchGrasped')
         rospy.sleep(0.1)
         status = rospy.get_param('smach_state')

--- a/mbzirc_c2_state/bin/mbzirc_ch2_sm.py
+++ b/mbzirc_c2_state/bin/mbzirc_ch2_sm.py
@@ -77,7 +77,8 @@ class InitSimulation(smach.State):
                              outcomes=['normal',
                                        'armTest',
                                        'wrenchTest',
-                                       'valveTest'],
+                                       'valveTest',
+                                       'manOpsTest'],
                              input_keys=['sim_type_in'])
 
     def execute(self, userdata):
@@ -101,7 +102,7 @@ class InitSimulation(smach.State):
         rospy.loginfo("Running in %s mode.", userdata.sim_type_in)
 
         # Sleep to allow the user to pause
-        rospy.sleep(5)
+        rospy.sleep(0.5)
         return userdata.sim_type_in
 
 
@@ -126,7 +127,8 @@ def main(sim_mode):
 
         # Create the sub SMACH state machine for navigation
         sm_nav = smach.StateMachine(outcomes=['readyToOrient',
-                                              'failedToNavigate'])
+                                              'unableToLocalize',
+                                              'unableToFindBoard'])
 
         # Create the sub SMACH state machine for orienting
         sm_orient = smach.StateMachine(outcomes=['readyToGrabWrench',
@@ -153,9 +155,12 @@ def main(sim_mode):
         #   'armTest'    : Test the arm for range of motion and stability
         #   'wrenchTest' : Test the wrench manipulation
         #   'valveTest'  : Test the valve operation
+        #   'manOpsTest' : Test manual keyboard operation of the UGV
         sm.userdata.sim_type = sim_mode
 
         # Define userdata for the state machines
+        sm_orient.userdata.num_sides = 0
+
         sm_wrench.userdata.move_counter = 0
         sm_wrench.userdata.max_move_retries = 1
         sm_wrench.userdata.have_wrench = False
@@ -171,12 +176,15 @@ def main(sim_mode):
                                transitions={'normal' : 'NAVIGATE',
                                             'armTest' : 'TEST_ARM',
                                             'wrenchTest' : 'TEST_WRENCH',
-                                            'valveTest' : 'TEST_VALVE'},
+                                            'valveTest' : 'TEST_VALVE',
+                                            'manOpsTest' : 'TEST_MANUAL_OPS'},
                                remapping={'sim_type_in' : 'sim_type'})
 
 
         smach.StateMachine.add('NAVIGATE', sm_nav,
-                               transitions={'readyToOrient' : 'ORIENT'})
+                               transitions={'readyToOrient' : 'ORIENT',
+                                            'unableToLocalize' : 'failure',
+                                            'unableToFindBoard' : 'failure'})
 
         smach.StateMachine.add('ORIENT', sm_orient,
                                transitions={'readyToGrabWrench' : 'GRAB_WRENCH',
@@ -210,14 +218,52 @@ def main(sim_mode):
                                transitions={'valveOpTestComplete' : 'OPERATE_VALVE',
                                             'valveOpTestFailed' : 'failure'})
 
+        smach.StateMachine.add('TEST_MANUAL_OPS', TestManualOps(),
+                               transitions={'manualOpsComplete' : 'success',
+                                            'manualOpsFailed' : 'failure'})
+
+
+
 
 
 
         #******************************************************************
         # Define the NAVIGATE State Machine (sm_nav)
         with sm_nav:
+            smach.StateMachine.add('NAV_SM_METHOD', NavSMMethod(),
+                                   transitions={'useOld' : 'FINDBOARD',
+                                                'useNew' : 'LOCALIZE'})
+
             smach.StateMachine.add('FINDBOARD', FindBoard(),
                                    transitions={'atBoard' : 'readyToOrient'})
+
+            smach.StateMachine.add('LOCALIZE', Localize(),
+                                   transitions={'localized' : 'INITIALIZE_DETECT',
+                                                'notLocalized' : 'VISUAL_LOCALIZATION'})
+
+            smach.StateMachine.add('VISUAL_LOCALIZATION', VisualLocalization(),
+                                   transitions={'localized' : 'INITIALIZE_DETECT',
+                                                'notLocalized' : 'unableToLocalize'})
+
+
+            smach.StateMachine.add('INITIALIZE_DETECT', InitializeDetect(),
+                                   transitions={'foundBoard' : 'MOVE_TO_BOARD',
+                                                'boardNotFound' : 'MOVE_TO_WAY_POINT'})
+
+            smach.StateMachine.add('MOVE_TO_WAY_POINT', MoveToWayPoint(),
+                                   transitions={'foundBoard' : 'MOVE_TO_BOARD',
+                                                'boardNotFound' : 'MOVE_TO_WAY_POINT',
+                                                'beenToAllWayPoints' : 'MANUAL_NAVIGATE'})
+
+
+            smach.StateMachine.add('MOVE_TO_BOARD', MoveToBoard(),
+                                   transitions={'atBoard' : 'readyToOrient',
+                                                'lostObject' : 'MOVE_TO_WAY_POINT'})
+
+
+            smach.StateMachine.add('MANUAL_NAVIGATE', ManualNavigate(),
+                                   transitions={'atBoard' : 'readyToOrient',
+                                                'noBoard' : 'unableToFindBoard'})
         # END NAVIGATE State Machine
         #******************************************************************
 
@@ -225,12 +271,18 @@ def main(sim_mode):
         #******************************************************************
         # Define the ORIENT State Machine (sm_orient)
         with sm_orient:
-            smach.StateMachine.add('ORIENT_HUSKY', Orient(),
+            smach.StateMachine.add('ORIENT_SM_METHOD', OrientSMMethod(),
+                                   transitions={'useOld' : 'ORIENT_UGV',
+                                                'useNew' : 'GO_TO_NEW_SIDE'})
+
+            smach.StateMachine.add('ORIENT_UGV', Orient(),
                                    transitions={'oriented' : 'readyToGrabWrench'})
 
             smach.StateMachine.add('GO_TO_NEW_SIDE', GoToNewSide(),
                                    transitions={'atNewSide' : 'COMPUTE_SIDE_WP',
-                                                'allSidesScanned' : 'MANUAL_ORIENT'})
+                                                'allSidesScanned' : 'MANUAL_ORIENT'},
+                                   remapping={'num_sides_in' : 'num_sides',
+                                              'num_sides_out' : 'num_sides'})
 
             smach.StateMachine.add('MANUAL_ORIENT', ManualOrient(),
                                    transitions={'backToAuto' : 'DETECT_WRENCHES',

--- a/mbzirc_c2_state/bin/mbzirc_ch2_sm.py
+++ b/mbzirc_c2_state/bin/mbzirc_ch2_sm.py
@@ -109,7 +109,14 @@ def main(sim_mode):
     """Defines the state machines for Smach
     """
 
-    rospy.init_node('mbzirc_simulation_state_machine', anonymous=True)
+    # Set the log level for the node
+    loglevel = rospy.get_param('node_logging')
+    if loglevel == 'DEBUG' or loglevel == 'SMACH_DEBUG':
+        rospy.init_node('mbzirc_ch2_sm', anonymous=True, log_level=rospy.DEBUG)
+    else:
+        rospy.init_node('mbzirc_ch2_sm', anonymous=True)
+
+    rospy.logdebug("SMACH logging in DEBUG mode.")
 
     # Create a SMACH state machine
     sm = smach.StateMachine(outcomes=['success', 'failure'])

--- a/mbzirc_c2_state/bin/navigate_states.py
+++ b/mbzirc_c2_state/bin/navigate_states.py
@@ -27,6 +27,37 @@ import smach
 import subprocess
 import os
 import signal
+import sys
+
+
+class NavSMMethod(smach.State):
+    """Determine if old or new state machine should be used
+
+    This should be removed as soon as the new state machine logic for navigation
+    has been implemented
+
+    Outcomes
+    --------
+        useNew : use the new state machine
+        useOld : use the old state machine
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['useNew',
+                                       'useOld'])
+
+    def execute(self, userdata):
+        try:
+            sm_to_use = rospy.get_param('sm_version')
+        except:
+            print sys.exc_info()[0]
+            return 'useOld'
+
+        if sm_to_use == 'new' or sm_to_use == 'newNavigate':
+            return 'useNew'
+        else:
+            return 'useOld'
 
 
 class FindBoard(smach.State):
@@ -35,7 +66,6 @@ class FindBoard(smach.State):
     Outcomes
     --------
         atBoard : at the board location
-
     """
 
     def __init__(self):
@@ -45,7 +75,7 @@ class FindBoard(smach.State):
     def execute(self, userdata):
 
         rospy.loginfo('Searching for board')
-        a = subprocess.Popen("rosrun mbzirc_c2_auto findbox.py", 
+        a = subprocess.Popen("rosrun mbzirc_c2_auto findbox.py",
             stdout=subprocess.PIPE, shell=True, preexec_fn=os.setsid)
         #a = subprocess.Popen("rosrun mbzirc_c2_auto findbox.py", shell=True)
         rospy.sleep(0.1)
@@ -53,8 +83,146 @@ class FindBoard(smach.State):
 
         b.wait()
         rospy.loginfo('Searching for board')
-        os.killpg(os.getpgid(a.pid), signal.SIGTERM) 
+        os.killpg(os.getpgid(a.pid), signal.SIGTERM)
         rospy.sleep(0.1)
 
         return 'atBoard'
+
+
+class Localize(smach.State):
+    """Automatically localize the UGV in the arena
+
+    Use IMU and GPS to localize the UGV in the arena
+
+    Outcomes
+    --------
+        localized : UGV localized in the arena
+        notLocalized : unable to automatically localize the UGV in the arena
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['localized',
+                                       'notLocalized'])
+
+    def execute(self, userdata):
+        return 'localized'
+
+
+class VisualLocalization(smach.State):
+    """Visually localize the UGV in the arena
+
+    Attempt to use visual localization to orient the UGV in the arena
+
+    Outcomes
+    --------
+        localized : UGV localized in the environment
+        notLocalized : unable to perform visual localization of the UGV
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['localized',
+                                       'notLocalized'])
+
+    def execute(self, userdata):
+        return 'localized'
+
+
+class InitializeDetect(smach.State):
+    """Initialize LiDAR and Visual detectors and perform initial arena scan
+
+    First initialize the LiDAR detector and the PTZ camera for visual detection. Perform
+    an initial scan of the arena to see if the board can be located
+
+    Outcomes
+    --------
+        boardFound : board found on the initial scan of the arena
+        boardNotFound : unable to locate the board on initial scan
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['foundBoard',
+                                       'boardNotFound'])
+
+    def execute(self, userdata):
+        return 'boardFound'
+
+
+class MoveToWayPoint(smach.State):
+    """Moves the UGV to the next navigation way point while searching for the board
+
+    This moves the UGV along a predetermined list of way points that define a search
+    pattern for locating the board.  Additionally it continually checks to see if the
+    board is located by the detector and if it has then it stops and hands the logic
+    off to drive to the board.  If all the way points have been visited then the
+    navigation is turned over to manual operations.
+
+    Outcomes
+    --------
+        foundBoard : board located while moving to the next way point
+        boardNotFound : at the way point and was unable to find the board
+        beenToAllWayPoints : visited every predefined way point and was unable to
+                             find the board
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['foundBoard',
+                                       'boardNotFound',
+                                       'beenToAllWayPoints'])
+
+    def execute(self, userdata):
+        return 'foundBoard'
+
+
+class MoveToBoard(smach.State):
+    """Moves the UGV to the predicted board location
+
+    The location of the board is predicted based on a combination of LiDAR and
+    visual detection.  This state drives the UGV towards the object and continually
+    checks the detectors to ensure that it is on a good course
+
+    Outcomes
+    --------
+        atBoard : completed the navigation to the board
+        lostObject : lost the object or determined it was the wrong object
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['atBoard',
+                                       'lostObject'])
+
+    def execute(self, userdata):
+        return 'atBoard'
+
+
+class ManualNavigate(smach.State):
+    """Manually navigate the UGV to find the tool and valve board
+
+    Shifts the operation to manual if the autonomous routines are unable to locate
+    the board after going to all the way points.
+
+    Outcomes
+    --------
+        atBoard : at the board ready to orient
+        noBoard : could not find the board
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['atBoard',
+                                       'noBoard'])
+
+    def execute(self, userdata):
+        prc = subprocess.Popen("rosrun mbzirc_c2_auto manual_ugv_drive.py", shell=True)
+        prc.wait()
+
+        if rospy.get_param('smach_state') == 'backToAuto':
+            return 'atBoard'
+        else:
+            return 'noBoard'
+
 

--- a/mbzirc_c2_state/bin/orient_states.py
+++ b/mbzirc_c2_state/bin/orient_states.py
@@ -25,6 +25,7 @@
 import rospy
 import smach
 import subprocess
+from std_msgs.msg import String
 
 
 class Orient(smach.State):
@@ -63,3 +64,176 @@ class Orient(smach.State):
         e.kill()
 
         return 'oriented'
+
+
+
+class GoToNewSide(smach.State):
+    """Moves to a new side of the panel
+
+    Moves the UGV to the next side of the panel in order to search for the wrenches.
+
+    Outcomes
+    --------
+        atNewSide : UGV located at the new panel side
+        allSidesScanned : all four sides of the panel have been visited
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['atNewSide',
+                                       'allSidesScanned'],
+                             input_keys=['sideCounter_in'],
+                             output_keys=['sideCounter_out'])
+
+    def execute(self, userdata):
+        userdata.sideCounter_out = userdata.sideCounter_in + 1;
+
+        if userdata.sideCounter_out > 4:
+            userdata.sideCounter_out = 0
+            rospy.loginfo('All panel sides searched - switching to manual mode.')
+            return 'allSidesScanned'
+
+        return 'atNewSide'
+
+
+class ComputeSideWP(smach.State):
+    """Computes the first way point at a new side of the panel
+
+    Computes the first way point at a new side.  Essentially this puts the right
+    edge of the panel near the right edge of the camera image.  This often puts
+    the entire panel in the field of view.  If not, then subsequent way points
+    along the side are computed in MOVE_DOWN_SIDE.
+
+    Outcomes
+    --------
+      computedWayPoint : first way point has been computed
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['computedWayPoint'])
+
+    def execute(self, userdata):
+        return 'computedWaypoint'
+
+
+class ManualOrient(smach.State):
+    """Allows for manual operation of the UGV if unable to find the wenches
+
+    If all four sides of the panel have been searched and we have failed to locate the
+    wrenches, then we would like to shift to manual operation of the UGV.  This state
+    provides the ability to do that.
+
+    Outcomes
+    --------
+      backToAuto : moves the system back to autonomous mode.
+      noWrenches : could not find the wrenches on any side of the panel
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['backToAuto',
+                                       'noWrenches'])
+
+    def execute(self, userdata):
+        prc = subprocess.Popen("rosrun mbzirc_c2_auto manual_orient.py", shell=True)
+        prc.wait()
+
+        return rospy.get_param('smach_state')
+
+
+class MoveToSideWP(smach.State):
+    """Moves the UGV to the next way point along the side
+
+    Moves the UGV to the next way point along a given side and then orients the UGV
+    to face the board in order to attempt to detect the wrenches.  The first way
+    point on any side places the right side of the panel on the right edge of the camera
+    field of view.  All subsequent way points move down the panel until the left edge
+    is reached.
+
+    Outcomes
+    --------
+        atWayPoint : UGV is located at the next way point and oriented facing the panel
+
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['atWayPoint'])
+
+    def execute(self, userdata):
+        return 'atWayPoint'
+
+
+
+class DetectWrenches(smach.State):
+    """Attempts to detect the bank of wrenches in the current camera FOV
+
+    Searches for the wrenches on the panel.  If found, the initial position is
+    stored in a parameter for later.
+
+    Outcomes
+    --------
+      oriented : Husky oriented to grasp wrench and turn valve
+
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['foundWrenches',
+                                       'noWrenches'])
+
+    def execute(self, userdata):
+        # Need to call a routing to detect the wrenches here.  wrench_detect.py just
+        # spins so we probably need to Subscribe to its output and determine the
+        # wrench/valve positions here
+
+        # return rospy.get_param('smach_state')
+        return 'foundWrenches'
+
+
+class MoveDownSide(smach.State):
+    """Moves down the wall to check for wrenches
+
+    This routine first checks to see if the left edge of the panel is in the
+    current view If it is, then this routine returns that it has finished processing
+    the current side. Otherwise, it calculates a new way point (WP) to move the
+    UGV to the left.
+
+    Outcomes
+    --------
+        finishedSide : left end of the panel is detected
+        nextWayPoint : move to new side way point
+
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['finishedSide',
+                                       'nextWayPoint'])
+
+    def execute(self, userdata):
+        return 'finishedSide'
+
+
+class MoveToWrenches(smach.State):
+    """Moves the Husky into position to ID and grab the wrench
+
+    Move the Husky closer to the board in preparation for grabbing the correct
+    wrench for operating the valve
+
+    Outcomes
+    --------
+       oriented : Husky oriented to ID and grab wrench
+
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['oriented'])
+
+    def execute(self, userdata):
+
+        return 'oriented'
+
+

--- a/mbzirc_c2_state/bin/robot_mv_cmds.py
+++ b/mbzirc_c2_state/bin/robot_mv_cmds.py
@@ -61,7 +61,7 @@ def moveArmTwist(x, y, z):
         if move_state == 'success':
             break
         else:
-            rospy.loginfo("Current move arm status is %s",move_state)
+            rospy.logdebug("Current move arm status is %s",move_state)
 
     return move_state
 

--- a/mbzirc_c2_state/bin/test_states.py
+++ b/mbzirc_c2_state/bin/test_states.py
@@ -139,6 +139,7 @@ class TestWrenchGrab(smach.State):
 
     def execute(self, userdata):
         rospy.loginfo("*** START WRENCH TEST ***")
+
         subprocess.Popen("rosrun mbzirc_c2_auto wrench_detect.py", shell=True)
         subprocess.Popen("rosrun mbzirc_c2_auto orient_scan.py", shell=True)
         rospy.sleep(5)

--- a/mbzirc_c2_state/bin/test_states.py
+++ b/mbzirc_c2_state/bin/test_states.py
@@ -3,8 +3,12 @@
     This file provides for testing states that can be used to test general functionality.
 
     Classes
-        FindBoard
+        TestArm
+        TestWrenchGrab
+        TestValveOps
+        TestManualOps
 
+    Author:
     Alan Lattimer (alattimer at jensenhughes dot com)
 
     This program is free software; you can redistribute it and/or modify
@@ -33,7 +37,7 @@ class TestArm(smach.State):
     Outcomes
     --------
         armTestComplete : arm tested
-
+        armTestFailed : something went wrong during the arm test
     """
 
     def __init__(self):
@@ -129,7 +133,7 @@ class TestWrenchGrab(smach.State):
     Outcomes
     --------
         wrenchTestComplete : at the board location ready to test the wrench
-
+        wrenchTestFailed : Test failed (not currently used)
     """
 
     def __init__(self):
@@ -148,11 +152,12 @@ class TestWrenchGrab(smach.State):
 
 
 class TestValveOp(smach.State):
-    """Searches for and then navigates to the board
+    """Test the valve operation state machine
 
     Outcomes
     --------
-        atBoard : at the board location
+        valveOpTestComplete : completed the valve operation test
+        valveOpTestFailed : failed the valve operation test
 
     """
 
@@ -162,6 +167,40 @@ class TestValveOp(smach.State):
                                        'valveOpTestFailed'])
 
     def execute(self, userdata):
+        """Main execution function
+        NOTE: This test has not yet been implemented yet.
+        """
         rospy.loginfo("*** START VALVE TEST ***")
         return 'valveOpTestComplete'
 
+
+class TestManualOps(smach.State):
+    """Tests manual operations of the UGV and Arm
+
+    Outcomes
+    --------
+        manualOpsComplete : successfully completed manual operations
+        manualOpsFailed : quit before fully testing the manual operations
+    """
+
+    def __init__(self):
+        smach.State.__init__(self,
+                             outcomes=['manualOpsComplete',
+                                       'manualOpsFailed'])
+
+    def execute(self, userdata):
+        prc = subprocess.Popen("rosrun mbzirc_c2_auto manual_ugv_drive.py", shell=True)
+        prc.wait()
+
+        curr_state = rospy.get_param('smach_state')
+        if curr_state != 'backToAuto':
+            return 'manualOpsFailed'
+
+        prc = subprocess.Popen("rosrun mbzirc_c2_auto manual_arm_move.py", shell=True)
+        prc.wait()
+
+        curr_state = rospy.get_param('smach_state')
+        if curr_state == 'endArmMove':
+            return 'manualOpsFailed'
+        else:
+            return 'manualOpsComplete'


### PR DESCRIPTION
Created new state machines for orient and navigate to break down the work into smaller steps for future tracking.  Initial unit testing hast been completed, but further testing will be required once the states have been implemented.  To control which version of the state machine is used, set the parameter 'sm_version' as follows:
  'old' - use the old state machines
  'new' - use new state machine for Navigate and Orient
  'newNavigate'  - use new state machine for Navigate only
  'newOrient' - use new state machine for Orient only
If 'sm_version' is not set, it will default to using the old state machines.

Also, the backbone structure and files for teleop operations of the UGV and Arm have been written.  Specific move commands still need to be added.